### PR TITLE
fix: SQL input타입 String에서 Date로 수정

### DIFF
--- a/MJDonor/src/main/java/com/db/ConnectDB.java
+++ b/MJDonor/src/main/java/com/db/ConnectDB.java
@@ -149,8 +149,8 @@ public class ConnectDB {
             pstmt.setString(2, name);
             pstmt.setString(3, description);
             pstmt.setInt(4, target_point);
-            pstmt.setString(5, start_date);
-            pstmt.setString(6, end_date);
+            pstmt.setDate(5, java.sql.Date.valueOf(start_date));
+            pstmt.setDate(6, java.sql.Date.valueOf(end_date));
             pstmt.setString(7, image1);
             pstmt.setString(8, image2);
             pstmt.setString(9, category);


### PR DESCRIPTION
## 주요 내용

performRegister.jsp의 쿼리필드로 날짜삽입시 SQL Exception 발생하는 버그 해결
- 원인: datetime 필드에  Date type이 아닌 String type으로 SQL에 값을 전달함.
- 해결: `setDate(index, java.sql.Date.valueOf(string_data));` 형식으로 수정함.